### PR TITLE
Lugg-529: Consistency in Content Types

### DIFF
--- a/luggage_news.features.field_base.inc
+++ b/luggage_news.features.field_base.inc
@@ -13,7 +13,7 @@ function luggage_news_field_default_field_bases() {
   // Exported field_base: 'field_news_files'
   $field_bases['field_news_files'] = array(
     'active' => 1,
-    'cardinality' => 10,
+    'cardinality' => -1,
     'deleted' => 0,
     'entity_types' => array(),
     'field_name' => 'field_news_files',

--- a/luggage_news.strongarm.inc
+++ b/luggage_news.strongarm.inc
@@ -57,13 +57,13 @@ function luggage_news_strongarm() {
           'weight' => '0',
         ),
         'path' => array(
-          'weight' => '7',
+          'weight' => '8',
         ),
         'redirect' => array(
           'weight' => '7',
         ),
         'xmlsitemap' => array(
-          'weight' => '6',
+          'weight' => '7',
         ),
       ),
       'display' => array(),


### PR DESCRIPTION
Made two changes to make luggage_news more like other content types:
- Switched around the order of fields in the content type creation form so that all the metadata fields were at the very bottom
- Changed the file upload limit from 10 to unlimited
