### PR TITLE
LUGG-654 - Add read more settings

### DIFF
--- a/luggage_news.info
+++ b/luggage_news.info
@@ -43,6 +43,7 @@ features[variable][] = node_options_news
 features[variable][] = node_preview_news
 features[variable][] = node_submitted_news
 features[variable][] = publishcontent_news
+features[variable][] = read_more_news_view_modes
 features[views_view][] = news
 features_exclude[dependencies][flexslider_fields] = flexslider_fields
 github = https://raw.github.com/isubit/luggage_news/master/luggage_news.info

--- a/luggage_news.strongarm.inc
+++ b/luggage_news.strongarm.inc
@@ -116,5 +116,22 @@ function luggage_news_strongarm() {
   $strongarm->value = 1;
   $export['publishcontent_news'] = $strongarm;
 
+  $strongarm = new stdClass();
+  $strongarm->disabled = FALSE; /* Edit this to true to make a default strongarm disabled initially */
+  $strongarm->api_version = 1;
+  $strongarm->name = 'read_more_news_view_modes';
+  $strongarm->value = array(
+    'teaser' => 'teaser',
+    'search_result' => 'search_result',
+    'full' => 0,
+    'rss' => 0,
+    'search_index' => 0,
+    'diff_standard' => 0,
+    'token' => 0,
+    'revision' => 0,
+  );
+  
+  $export['read_more_news_view_modes'] = $strongarm;
+
   return $export;
 }


### PR DESCRIPTION
Added strongarm settings for the read more module.

To test:
Pull down these changes on a site with an updated version of the read more module
Run "drush fra -y" on the site you're using for testing
Go to Administration > Configuration > Content Authoring > Read More link
Scroll down to the "Content Types" section of configuration
Verify that teaser and search result highlighting input boxes are both checked for news
