### PR TITLE
LUGG-1003 Added display settings for frontpanel

### DIFF
--- a/luggage_news.features.field_instance.inc
+++ b/luggage_news.features.field_instance.inc
@@ -10,7 +10,7 @@
 function luggage_news_field_default_field_instances() {
   $field_instances = array();
 
-  // Exported field_instance: 'node-news-body'
+  // Exported field_instance: 'node-news-body'.
   $field_instances['node-news-body'] = array(
     'bundle' => 'news',
     'default_value' => NULL,
@@ -22,6 +22,15 @@ function luggage_news_field_default_field_instances() {
         'module' => 'text',
         'settings' => array(),
         'type' => 'text_default',
+        'weight' => 0,
+      ),
+      'frontpanel' => array(
+        'label' => 'hidden',
+        'module' => 'text',
+        'settings' => array(
+          'trim_length' => 600,
+        ),
+        'type' => 'text_summary_or_trimmed',
         'weight' => 0,
       ),
       'full' => array(
@@ -77,7 +86,7 @@ function luggage_news_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-news-field_category'
+  // Exported field_instance: 'node-news-field_category'.
   $field_instances['node-news-field_category'] = array(
     'bundle' => 'news',
     'default_value' => NULL,
@@ -89,6 +98,12 @@ function luggage_news_field_default_field_instances() {
         'module' => 'taxonomy',
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
+        'weight' => 2,
+      ),
+      'frontpanel' => array(
+        'label' => 'inline',
+        'settings' => array(),
+        'type' => 'hidden',
         'weight' => 2,
       ),
       'full' => array(
@@ -135,7 +150,7 @@ function luggage_news_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-news-field_news_alternate_url'
+  // Exported field_instance: 'node-news-field_news_alternate_url'.
   $field_instances['node-news-field_news_alternate_url'] = array(
     'bundle' => 'news',
     'default_value' => NULL,
@@ -148,6 +163,12 @@ function luggage_news_field_default_field_instances() {
         'settings' => array(),
         'type' => 'link_default',
         'weight' => 6,
+      ),
+      'frontpanel' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 4,
       ),
       'full' => array(
         'label' => 'above',
@@ -210,7 +231,7 @@ function luggage_news_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-news-field_news_files'
+  // Exported field_instance: 'node-news-field_news_files'.
   $field_instances['node-news-field_news_files'] = array(
     'bundle' => 'news',
     'deleted' => 0,
@@ -221,6 +242,12 @@ function luggage_news_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 5,
+      ),
+      'frontpanel' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 6,
       ),
       'full' => array(
         'label' => 'above',
@@ -286,7 +313,7 @@ function luggage_news_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-news-field_news_images'
+  // Exported field_instance: 'node-news-field_news_images'.
   $field_instances['node-news-field_news_images'] = array(
     'bundle' => 'news',
     'deleted' => 0,
@@ -297,6 +324,12 @@ function luggage_news_field_default_field_instances() {
         'settings' => array(),
         'type' => 'hidden',
         'weight' => 4,
+      ),
+      'frontpanel' => array(
+        'label' => 'above',
+        'settings' => array(),
+        'type' => 'hidden',
+        'weight' => 5,
       ),
       'full' => array(
         'label' => 'above',
@@ -370,7 +403,7 @@ function luggage_news_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-news-field_news_type'
+  // Exported field_instance: 'node-news-field_news_type'.
   $field_instances['node-news-field_news_type'] = array(
     'bundle' => 'news',
     'default_value' => NULL,
@@ -382,6 +415,12 @@ function luggage_news_field_default_field_instances() {
         'module' => 'taxonomy',
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
+        'weight' => 1,
+      ),
+      'frontpanel' => array(
+        'label' => 'inline',
+        'settings' => array(),
+        'type' => 'hidden',
         'weight' => 1,
       ),
       'full' => array(
@@ -428,7 +467,7 @@ function luggage_news_field_default_field_instances() {
     ),
   );
 
-  // Exported field_instance: 'node-news-field_tags'
+  // Exported field_instance: 'node-news-field_tags'.
   $field_instances['node-news-field_tags'] = array(
     'bundle' => 'news',
     'default_value' => NULL,
@@ -441,6 +480,12 @@ Baseball, bat, glove, ...',
         'module' => 'taxonomy',
         'settings' => array(),
         'type' => 'taxonomy_term_reference_link',
+        'weight' => 3,
+      ),
+      'frontpanel' => array(
+        'label' => 'inline',
+        'settings' => array(),
+        'type' => 'hidden',
         'weight' => 3,
       ),
       'full' => array(

--- a/luggage_news.strongarm.inc
+++ b/luggage_news.strongarm.inc
@@ -54,6 +54,9 @@ function luggage_news_strongarm() {
       'revision' => array(
         'custom_settings' => FALSE,
       ),
+      'frontpanel' => array(
+        'custom_settings' => TRUE,
+      ),
     ),
     'extra_fields' => array(
       'form' => array(


### PR DESCRIPTION
To test:

- Make sure you have the changes from this branch: isubit/luggage_roles#19
- pull down this branch and revert the luggage_roles feature
- make a news item
- add it to the front panel with the "Frontpanel" ds view
- Does page have categories? Does page have tags? Is there a read_more link? The answer to all these questions should be "no."