### PR TITLE
LUGG-1006 Changed body text settings to 'Summary or Trimmed'

### DIFF
--- a/luggage_news.views_default.inc
+++ b/luggage_news.views_default.inc
@@ -141,9 +141,8 @@ function luggage_news_views_default_views() {
   $handler->display->display_options['fields']['body']['field'] = 'body';
   $handler->display->display_options['fields']['body']['label'] = '';
   $handler->display->display_options['fields']['body']['alter']['max_length'] = '300';
-  $handler->display->display_options['fields']['body']['alter']['trim'] = TRUE;
   $handler->display->display_options['fields']['body']['element_label_colon'] = FALSE;
-  $handler->display->display_options['fields']['body']['type'] = 'text_plain';
+  $handler->display->display_options['fields']['body']['type'] = 'text_summary_or_trimmed';
   $handler->display->display_options['fields']['body']['settings'] = array(
     'trim_length' => '300',
   );


### PR DESCRIPTION
Using the trimmed body text means that any text entered into the summary part of the body field is ignored. This will make luggage_news match users' expectations.

To test:
- Pull down this branch
- Add luggage_news items with a different body and summary
- Check the news page view to see if your news items are using the summary field instead of the full body field where you've filled it in.